### PR TITLE
Remove binary exe from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Build artifacts
+/build/
+/.gradle/
+standalone/build/
+standalone/.gradle/
+/compiled/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Jenny Mod Standalone Game
+
+This project contains the original Jenny Mod code along with a `standalone` module
+that launches a very small LWJGL window. The module is a starting point for
+turning the mod into its own game.
+
+## Building
+
+Run `gradle build` from the `standalone` directory or from the project root if
+you have the Gradle wrapper installed.
+
+### Windows EXE
+
+You can create a Windows executable using the `launch4j` plugin. Simply run
+`gradle createExe` inside the `standalone` directory. The build copies
+`JennyModGame.exe` into a `compiled/` folder at the project root (this folder
+is ignored by Git), while the raw Launch4j output stays in
+`standalone/build/launch4j/`. If you just need to copy an existing build
+again, you can run `gradle packageExe` instead. The executable itself is not
+checked into the repository to avoid committing large binary files.
+
+## Running
+
+Use `gradle run` in the `standalone` directory. The task attempts to open a
+GLFW window, so it requires an environment with a graphical display.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'sexmod'
+
+// include standalone game module
+include('standalone')

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'application'
+    id 'edu.sc.seis.launch4j' version '3.0.6'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.lwjgl:lwjgl:3.3.1'
+    implementation 'org.lwjgl:lwjgl-glfw:3.3.1'
+    implementation 'org.lwjgl:lwjgl-opengl:3.3.1'
+
+    // native libraries for all major platforms
+    runtimeOnly 'org.lwjgl:lwjgl:3.3.1:natives-linux'
+    runtimeOnly 'org.lwjgl:lwjgl:3.3.1:natives-windows'
+    runtimeOnly 'org.lwjgl:lwjgl:3.3.1:natives-macos'
+
+    runtimeOnly 'org.lwjgl:lwjgl-glfw:3.3.1:natives-linux'
+    runtimeOnly 'org.lwjgl:lwjgl-glfw:3.3.1:natives-windows'
+    runtimeOnly 'org.lwjgl:lwjgl-glfw:3.3.1:natives-macos'
+
+    runtimeOnly 'org.lwjgl:lwjgl-opengl:3.3.1:natives-linux'
+    runtimeOnly 'org.lwjgl:lwjgl-opengl:3.3.1:natives-windows'
+    runtimeOnly 'org.lwjgl:lwjgl-opengl:3.3.1:natives-macos'
+}
+
+application {
+    mainClass = 'com.schnurritv.sexgame.GameLauncher'
+}
+
+launch4j {
+    mainClassName = application.mainClass
+    outfile = 'JennyModGame.exe'
+}
+
+// Package the generated exe to the repository's compiled folder
+tasks.register('packageExe', Copy) {
+    dependsOn tasks.named('createExe')
+    from "$buildDir/launch4j/JennyModGame.exe"
+    into "${projectDir.parentFile}/compiled"
+}
+
+// Ensure the exe is copied when createExe runs directly
+tasks.named('createExe') {
+    finalizedBy tasks.named('packageExe')
+}

--- a/standalone/settings.gradle
+++ b/standalone/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sexmod-game'

--- a/standalone/src/main/java/com/schnurritv/sexgame/GameLauncher.java
+++ b/standalone/src/main/java/com/schnurritv/sexgame/GameLauncher.java
@@ -1,0 +1,73 @@
+package com.schnurritv.sexgame;
+
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.glfw.GLFWVidMode;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.system.MemoryStack;
+
+import java.nio.IntBuffer;
+
+import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
+import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.system.MemoryUtil.NULL;
+
+public class GameLauncher {
+    private long window;
+
+    public static void main(String[] args) {
+        new GameLauncher().run();
+    }
+
+    public void run() {
+        init();
+        loop();
+        glfwFreeCallbacks(window);
+        glfwDestroyWindow(window);
+        glfwTerminate();
+        glfwSetErrorCallback(null).free();
+    }
+
+    private void init() {
+        GLFWErrorCallback.createPrint(System.err).set();
+        if (!glfwInit()) {
+            throw new IllegalStateException("Unable to initialize GLFW");
+        }
+        glfwDefaultWindowHints();
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+        window = glfwCreateWindow(800, 600, "Jenny Mod Game", NULL, NULL);
+        if (window == NULL) {
+            throw new RuntimeException("Failed to create the GLFW window");
+        }
+        glfwSetKeyCallback(window, (w, key, scancode, action, mods) -> {
+            if (key == GLFW_KEY_ESCAPE && action == GLFW_RELEASE) {
+                glfwSetWindowShouldClose(w, true);
+            }
+        });
+        try (MemoryStack stack = stackPush()) {
+            IntBuffer pWidth = stack.mallocInt(1);
+            IntBuffer pHeight = stack.mallocInt(1);
+            glfwGetWindowSize(window, pWidth, pHeight);
+            GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+            glfwSetWindowPos(
+                window,
+                (vidmode.width() - pWidth.get(0)) / 2,
+                (vidmode.height() - pHeight.get(0)) / 2
+            );
+        }
+        glfwMakeContextCurrent(window);
+        glfwSwapInterval(1);
+        glfwShowWindow(window);
+    }
+
+    private void loop() {
+        GL.createCapabilities();
+        while (!glfwWindowShouldClose(window)) {
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            glfwSwapBuffers(window);
+            glfwPollEvents();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- exclude `compiled/` from Git tracking
- clarify in README that the Windows executable isn't committed
- delete previously committed `JennyModGame.exe`

## Testing
- `gradle build` in `standalone`
- `gradle createExe` in `standalone`
- `gradle run` in `standalone` *(fails: GLFW platform unavailable)*
- `gradle build` in repo root *(fails: net.minecraftforge plugin missing)*


------
https://chatgpt.com/codex/tasks/task_e_684495cbe370832e97039553a4efe55e